### PR TITLE
Adding histogram range to tooltip (plus some formatting)

### DIFF
--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -64,7 +64,9 @@ $ ->
               xField = @series.xAxis.options.title.text
               idx = data.fields.map((x) -> fieldTitle(x)).indexOf(xField)
               str  = "<div style='width:100%;text-align:center;color:#{@series.color};'> "
-              str += "Bin #{@x}<br>Contains #{@total} Items</div><br>"
+              str += "Bin #{@x}<br>"
+              str += "Contains #{@total} Items<br>"
+              str += "Within the Range #{@x - document.getElementById("bin-size").value/2} - #{@x + document.getElementById("bin-size").value/2}</div><br>"
               str += "<table>"  
               str += "<tr><td>Group:&nbsp;</td><td>#{@series.name}</td></tr>"
               if @y > 0

--- a/app/assets/javascripts/visualizations/highvis/histogram.coffee
+++ b/app/assets/javascripts/visualizations/highvis/histogram.coffee
@@ -68,12 +68,12 @@ $ ->
               str += "Contains #{@total} Items<br>"
               str += "Within the Range #{@x - document.getElementById("bin-size").value/2} - #{@x + document.getElementById("bin-size").value/2}</div><br>"
               str += "<table>"  
-              str += "<tr><td>Group:&nbsp;</td><td>#{@series.name}</td></tr>"
+              str += "<tr><td style='text-align: right'>Group :&nbsp;</td><td>#{@series.name}</td></tr>"
               if @y > 0
                 if @y is 1
-                  str += "<tr><td>#{xField}:&nbsp;</td><td>#{@point.realValue}</td></tr>"
+                  str += "<tr><td style='text-align: right'>#{xField} :&nbsp;</td><td>#{@point.realValue}</td></tr>"
                 else
-                  str += "<tr><td>Data Points:&nbsp;</td><td>#{@y} in this Bin</td></tr>"
+                  str += "<tr><td style='text-align: right'>Data Points :&nbsp;</td><td>#{@y} in this Bin</td></tr>"
               str += "</table>"
             useHTML: true
           plotOptions:


### PR DESCRIPTION
In accordance with bug #1470, fixing up tooltip by adding a range feature so its more obvious to users what the range of values may be contained in the bin.

Merging this bug fix into this branch because it touches a lot of the same code.
Enjoy.

![pull_requested_tooltip](https://cloud.githubusercontent.com/assets/12720180/22305840/013a1d30-e30b-11e6-946d-c197a6a6ea97.png)